### PR TITLE
<Memory> tag missing from mcelog configuration

### DIFF
--- a/puppet-barometer/templates/mcelog.conf.erb
+++ b/puppet-barometer/templates/mcelog.conf.erb
@@ -15,7 +15,12 @@
 <LoadPlugin mcelog>
   Interval 1
 </LoadPlugin>
+
 <Plugin "mcelog">
-   McelogClientSocket "/var/run/mcelog-client"
+  <Memory>
+    McelogClientSocket "/var/run/mcelog-client"
+    PersistentNotification false
+  </Memory>
+##  McelogLogfile "/var/log/mcelog"   
 </Plugin>
 


### PR DESCRIPTION
Fix for current apex deployment issue